### PR TITLE
ci: add Appveyor API trigger for Kivy Windows nightly wheels

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:3.6
+
+RUN set -ex \
+    && apk add --no-cache curl
+
+COPY ci/script.sh /
+
+RUN \
+    chmod +x /script.sh && \
+    (crontab -l 2>/dev/null; \
+        echo "$APPVEYOR_SCHEDULE /script.sh \
+        >> /var/log/syslog 2>&1" \
+    )| crontab -
+
+# run CRON daemon in foreground
+# to keep the container running
+ENTRYPOINT crond -f -L /var/log/syslog

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+curl \
+    --url https://ci.appveyor.com/api/builds \
+    --request POST \
+    --header "Authorization: Bearer $APPVEYOR_API_TOKEN" \
+    --header "Content-Type: application/json" \
+    --data " \
+    { \
+        \"accountName\": \"KivyOrg\", \
+        \"projectSlug\": \"kivy\", \
+        \"branch\": \"master\", \
+        \"environmentVariables\": { \
+            \"APPVEYOR_SCHEDULED_BUILD\": \"True\" \
+        } \
+    } \
+    "

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,17 @@ services:
   #   logging:
   #     <<: *logging
 
+  ci:
+    build:
+      context: .
+      dockerfile: ci/Dockerfile
+    environment:
+      - APPVEYOR_SCHEDULE=0 7 * * *  # At 07:00.
+    env_file:
+      - .env/envfile/ci
+    logging:
+      <<: *logging
+
 volumes:
   blog_content:
   blog_mysql_data:


### PR DESCRIPTION
Just a simple POST request which allows us to go live with the nightly wheels even after Appveyor disabled them by default.

Get Appveyor API token from https://ci.appveyor.com/api-token. I already added it, so the container should pick it up like the `downloads` container does.

closes https://github.com/kivy/kivy/issues/5713