### PR TITLE
Fix CI image not receiving APPVEYOR_SCHEDULE variable

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,6 +5,7 @@ RUN set -ex \
 
 COPY ci/script.sh /
 
+ARG APPVEYOR_SCHEDULE
 RUN \
     chmod +x /script.sh && \
     (crontab -l 2>/dev/null; \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,8 +138,8 @@ services:
     build:
       context: .
       dockerfile: ci/Dockerfile
-    environment:
-      - APPVEYOR_SCHEDULE=0 7 * * *  # At 07:00.
+      args:
+        APPVEYOR_SCHEDULE: "0 5 * * *"  # At 05:00
     env_file:
       - .env/envfile/ci
     logging:


### PR DESCRIPTION
Little clean-up and moving the cron to UTC 5AM which IIRC that was the original time, but I can't find the logs related to the correct time, unfortunately.