### PR TITLE
fix: exclude ci folder from backup and prune linux and macOS dev wheels

### DIFF
--- a/downloads/cont/config/exclude-backup.conf
+++ b/downloads/cont/config/exclude-backup.conf
@@ -1,2 +1,3 @@
 appveyor/kivy/**
 appveyor/kivent/**
+ci/**

--- a/downloads/cont/script/start.sh
+++ b/downloads/cont/script/start.sh
@@ -7,8 +7,10 @@ fi
 
 if [ ! -f /etc/periodic/clean-ci ]; then
   cat << EOF > /etc/periodic/clean-ci
-$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/appveyor/kivy --older-than 30 --keep-last 18 >> /dev/null 2>&1
+$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/appveyor/kivy --older-than 30 --keep-last 20 >> /dev/null 2>&1
 $(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/appveyor/kivent --older-than 30 --keep-last 48 >> /dev/null 2>&1
+$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/ci/linux/kivy --older-than 30 --keep-last 10 >> /dev/null 2>&1
+$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/ci/osx/kivy --older-than 30 --keep-last 10 >> /dev/null 2>&1
 
 EOF
   chmod 0644 /etc/periodic/clean-ci


### PR DESCRIPTION
Fix for https://github.com/kivy/kivy/issues/5915.