### PR TITLE
feat: deploy mcnotify

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,18 +132,6 @@ services:
     logging:
       <<: *logging
 
-  # adminer:
-  #   init: true
-  #   build:
-  #     context: adminer
-  #   volumes:
-  #     - /adminer
-  #   links:
-  #     - blog_mysql
-  #     - piwik_mysql
-  #   logging:
-  #     <<: *logging
-
   ci:
     init: true
     build:
@@ -155,6 +143,31 @@ services:
       - .env/envfile/ci
     logging:
       <<: *logging
+
+  mcnotify:
+    init: true
+    build:
+      context: mcnotify
+    environment:
+      - NODE_ENV=production
+      - WEBHOOK_PATH=/mcnotify
+      - DISABLE_STATS=true
+    env_file:
+      - .env/envfile/mcnotify
+    logging:
+      <<: *logging
+
+  # adminer:
+  #   init: true
+  #   build:
+  #     context: adminer
+  #   volumes:
+  #     - /adminer
+  #   links:
+  #     - blog_mysql
+  #     - piwik_mysql
+  #   logging:
+  #     <<: *logging
 
 volumes:
   blog_content:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,7 @@ services:
       - blog
       - piwik
       - kgb
+      - mcnotify
       # - adminer
     environment:
       - BOOTSTRAP_TLS=false

--- a/mcnotify/Dockerfile
+++ b/mcnotify/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:8.12.0-alpine
+
+ENV APP_VERSION v0.1.0
+
+WORKDIR /web/app
+
+RUN set -ex \
+    && apk add --no-cache curl \
+    && curl -Lf https://github.com/kivy/mcnotify/archive/$APP_VERSION.tar.gz > app.tar.gz \
+    && tar -xf app.tar.gz --strip-components=1 && rm app.tar.gz \
+    && yarn install --ignore-engines --production \
+    && apk del curl
+
+EXPOSE 3000
+
+CMD ["yarn", "start"]

--- a/nginx/conf/sites-enabled/kivy.org.conf
+++ b/nginx/conf/sites-enabled/kivy.org.conf
@@ -91,6 +91,16 @@ server {
         proxy_redirect off;
         proxy_pass http://kgb:5000;
     }
+
+    location ~ ^/mcnotify {
+        add_header Cache-Control "no-cache";
+        proxy_set_header Proxy "";
+        proxy_set_header   X-Forwarded-Proto    $scheme;
+        proxy_set_header   X-Forwarded-Host     $http_host;
+        proxy_set_header   X-Forwarded-For      $remote_addr;
+        proxy_redirect off;
+        proxy_pass http://mcnotify:3000;
+    }
 }
 
 


### PR DESCRIPTION
The repo for the app we use to notify users about breaking changes was moved from my account to https://github.com/kivy/mcnotify.

A private GitHub app has been created under the kivy org: https://github.com/organizations/kivy/settings/apps/mcnotify

This pr deploys the app on the server.