### PR TITLE
Don't keep as much history and also remove dmgs.

### DIFF
--- a/downloads/cont/script/remove-wheels.sh
+++ b/downloads/cont/script/remove-wheels.sh
@@ -25,12 +25,12 @@ KEEP_LAST="${KEEP_LAST:-0}"
 
 cd "${DIRECTORY}" || exit 1
 
-if ! ls *whl 1> /dev/null 2>&1; then
+if ! ls *.* 1> /dev/null 2>&1; then
   exit
 fi
 
 if [ "${KEEP_LAST}" -gt 0 ]; then
-  EXCLUDE=$(printf "! -name %s " $(ls -t *.whl | head -"${KEEP_LAST}"))
+  EXCLUDE=$(printf "! -name %s " $(ls -t *.* | head -"${KEEP_LAST}"))
 fi
 
-find . -maxdepth 1 -type f -mtime +"${OLDER_THAN}" -name "*.whl" ${EXCLUDE} -exec rm -- {} \;
+find . -maxdepth 1 -type f -mtime +"${OLDER_THAN}" -name "*.*" ${EXCLUDE} -exec rm -- {} \;

--- a/downloads/cont/script/start.sh
+++ b/downloads/cont/script/start.sh
@@ -7,10 +7,11 @@ fi
 
 if [ ! -f /etc/periodic/clean-ci ]; then
   cat << EOF > /etc/periodic/clean-ci
-$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/appveyor/kivy --older-than 30 --keep-last 20 >> /dev/null 2>&1
-$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/appveyor/kivent --older-than 30 --keep-last 48 >> /dev/null 2>&1
-$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/ci/linux/kivy --older-than 30 --keep-last 10 >> /dev/null 2>&1
-$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/ci/osx/kivy --older-than 30 --keep-last 10 >> /dev/null 2>&1
+$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/appveyor/kivy --older-than 7 --keep-last 20 >> /dev/null 2>&1
+$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/appveyor/kivent --older-than 7 --keep-last 48 >> /dev/null 2>&1
+$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/ci/linux/kivy --older-than 7 --keep-last 10 >> /dev/null 2>&1
+$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/ci/osx/kivy --older-than 7 --keep-last 10 >> /dev/null 2>&1
+$(shuf -i0-59 -n1) 0 * * * /cont/script/remove-wheels.sh -d /web/downloads/ci/osx/app --keep-last 6 >> /dev/null 2>&1
 
 EOF
   chmod 0644 /etc/periodic/clean-ci


### PR DESCRIPTION
In the lest kivy.deps.xxx generation attempt, we ran out of space. This keeps less history and also removes all CI generated files including dmg files etc.