### PR TITLE
Add pypi server for dev wheels

### DIFF
--- a/downloads/cont/script/pypi_server.sh
+++ b/downloads/cont/script/pypi_server.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+server_path="/web/downloads/simple/kivy"
+
+echo -e "<!DOCTYPE html>\n<html>\n  <head>\n    <title>Links for Kivy</title>\n  </head>\n  <body>\n    <h1>Links for Kivy</h1>" > /tmp/kivy_pypi_index.html
+
+
+for f in /web/downloads/ci/win/kivy /web/downloads/ci/osx/kivy /web/downloads/ci/linux/kivy
+do
+    find -L $f -name "*.whl" | grep -E '.+Kivy-([0-9a-z]{1,6}\.)+[0-9a-z]+-.+\.whl' | tr "\n" "\0" |
+        while IFS= read -r -d '' fname; do
+            relative_name=${fname#"/web/downloads/"}
+            clean_name=$(basename "$fname")
+            echo "    <a href="../../$relative_name">$clean_name</a><br>" >> /tmp/kivy_pypi_index.html
+        done
+done
+
+echo -e "  </body>\n</html>" >> /tmp/kivy_pypi_index.html
+mv /tmp/kivy_pypi_index.html $server_path/index.html

--- a/downloads/cont/script/pypi_server.sh
+++ b/downloads/cont/script/pypi_server.sh
@@ -4,16 +4,30 @@ server_path="/web/downloads/simple/kivy"
 
 echo -e "<!DOCTYPE html>\n<html>\n  <head>\n    <title>Links for Kivy</title>\n  </head>\n  <body>\n    <h1>Links for Kivy</h1>" > /tmp/kivy_pypi_index.html
 
-
 for f in /web/downloads/ci/win/kivy /web/downloads/ci/osx/kivy /web/downloads/ci/linux/kivy
 do
-    find -L $f -name "*.whl" | grep -E '.+Kivy-([0-9a-z]{1,6}\.)+[0-9a-z]+-.+\.whl' | tr "\n" "\0" |
+    find -L $f -name "*.whl" | sort | grep -E '.+Kivy-([0-9a-z]{1,6}\.)+[0-9a-z]+-.+\.whl' | tr "\n" "\0" |
         while IFS= read -r -d '' fname; do
             relative_name=${fname#"/web/downloads/"}
             clean_name=$(basename "$fname")
             echo "    <a href="../../$relative_name">$clean_name</a><br>" >> /tmp/kivy_pypi_index.html
         done
 done
+
+echo -e "  </body>\n</html>" >> /tmp/kivy_pypi_index.html
+mv /tmp/kivy_pypi_index.html $server_path/index.html
+
+
+server_path="/web/downloads/simple/kivy-examples"
+
+echo -e "<!DOCTYPE html>\n<html>\n  <head>\n    <title>Links for Kivy-examples</title>\n  </head>\n  <body>\n    <h1>Links for Kivy-examples</h1>" > /tmp/kivy_pypi_index.html
+
+find -L /web/downloads/ci/win/kivy -name "*.whl" | sort | grep -E '.+Kivy_examples-([0-9a-z]{1,6}\.)+[0-9a-z]+-.+\.whl' | tr "\n" "\0" |
+    while IFS= read -r -d '' fname; do
+        relative_name=${fname#"/web/downloads/"}
+        clean_name=$(basename "$fname")
+        echo "    <a href="../../$relative_name">$clean_name</a><br>" >> /tmp/kivy_pypi_index.html
+    done
 
 echo -e "  </body>\n</html>" >> /tmp/kivy_pypi_index.html
 mv /tmp/kivy_pypi_index.html $server_path/index.html

--- a/downloads/cont/script/start.sh
+++ b/downloads/cont/script/start.sh
@@ -17,6 +17,14 @@ EOF
   chmod 0644 /etc/periodic/clean-ci
 fi
 
+if [ ! -f /etc/periodic/pypi-server-ci ]; then
+  cat << EOF > /etc/periodic/pypi-server-ci
+$(shuf -i0-59 -n1) 0 * * * /cont/script/pypi_server.sh
+
+EOF
+  chmod 0644 /etc/periodic/pypi-server-ci
+fi
+
 if [ ! -f /root/.ssh/authorized_keys ]; then
   mkdir -p /root/.ssh
   mv /authorized_keys /root/.ssh/authorized_keys


### PR DESCRIPTION
This creates a pypi server for the dev wheels so people can install it just using `pip install kivy kivy_examples --pre --extra-index-url  https://kivy.org/downloads/simple/`.

You can find the index at https://kivy.org/downloads/simple/. I manually generated the current listing, but once merged, it should auto generate the listing daily.